### PR TITLE
Add support for multi-byte glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,6 @@ I don't have access to any Linux device that has any other kind of
 framebuffer. If somebody wants to provide me with one for testing
 purposes, be my guest. 
 
-The utility cannot at present handle multi-byte characters, even if
-you select a font file that has the correct glyphs. 
-
 Although `fbtextdemo` can render onto the existing contents of the
 framebuffer, it won't anti-alias properly if the background is anything
 other than black. It wouldn't be difficult to merge the rendered 

--- a/src/main.c
+++ b/src/main.c
@@ -291,6 +291,39 @@ void face_get_string_extent (const FT_Face face, const UTF32 *s,
   *y = y_extent;
   }
 
+  /*===========================================================================
+
+  next_utf8_glyph_length
+
+  Gets the length of next glyph in a UTF-8 sequence.
+
+  Returns -1 if the next glyph is not UTF-8.
+
+  =========================================================================*/
+int next_utf8_glyph_length(const UTF8 *word) {
+    assert(word != NULL);
+
+    // 1-byte glyph (0xxxxxxx).
+    if ((*word & 0x80) == 0) {
+        return 1;
+    }
+    // 2-byte glyph (110xxxxx).
+    else if ((*word & 0xE0) == 0xC0) {
+        return 2;
+    }
+    // 3-byte glyph (1110xxxx).
+    else if ((*word & 0xF0) == 0xE0) {
+        return 3;
+    }
+    // 4-byte glyph (11110xxx).
+    else if ((*word & 0xF8) == 0xF0) {
+        return 4;
+    }
+
+    // Invalid UTF-8 glyph.
+    return -1;
+}
+
 /*===========================================================================
 
   utf8_to_utf32 
@@ -304,18 +337,57 @@ void face_get_string_extent (const FT_Face face, const UTF32 *s,
     to 32-bit.
 
   =========================================================================*/
-UTF32 *utf8_to_utf32 (const UTF8 *word)
-  {
-  assert (word != NULL);
-  int l = strlen ((char *)word);
-  UTF32 *ret = malloc ((l + 1) * sizeof (UTF32));
-  for (int i = 0; i < l; i++)
-    {
-    ret[i] = (UTF32) word[i];
+UTF32 *utf8_to_utf32(const UTF8 *utf8_word)
+{
+    assert(utf8_word != NULL);
+
+    // Compute the length of the resulting UTF-32 sequence.
+    int word_length = 0;
+    const UTF8 *utf8_word_ptr = utf8_word;
+
+    while (*utf8_word_ptr) {
+        int curr_glyph_length = next_utf8_glyph_length(utf8_word_ptr);
+        utf8_word_ptr += curr_glyph_length;
+        word_length++;
     }
-  ret[l] = 0;
-  return ret;
-  }
+
+    // Allocate memory for the UTF-32 sequence.
+    UTF32 *utf32_word = (UTF32 *)malloc((word_length + 1) * sizeof(UTF32));
+    UTF32 *utf32_word_ptr = utf32_word;
+    utf8_word_ptr = utf8_word;
+
+    // Convert UTF-8 to UTF-32 sequence.
+    while (*utf8_word_ptr) {
+        int curr_glyph_length = next_utf8_glyph_length(utf8_word_ptr);
+        if (curr_glyph_length == 1) {
+            *utf32_word_ptr = *utf8_word_ptr;
+        }
+        else if (curr_glyph_length == 2) {
+            *utf32_word_ptr = ((*utf8_word_ptr & 0x1F) << 6);
+            *utf32_word_ptr |= (*(utf8_word_ptr + 1) & 0x3F);
+        }
+        else if (curr_glyph_length == 3) {
+            *utf32_word_ptr = ((*utf8_word_ptr & 0x0F) << 12);
+            *utf32_word_ptr |= ((*(utf8_word_ptr + 1) & 0x3F) << 6);
+            *utf32_word_ptr |= (*(utf8_word_ptr + 2) & 0x3F);
+        }
+        else if (curr_glyph_length == 4) {
+            *utf32_word_ptr = ((*utf8_word_ptr & 0x07) << 18);
+            *utf32_word_ptr |= ((*(utf8_word_ptr + 1) & 0x3F) << 12);
+            *utf32_word_ptr |= ((*(utf8_word_ptr + 2) & 0x3F) << 6);
+            *utf32_word_ptr |= (*(utf8_word_ptr + 3) & 0x3F);
+        }
+        utf32_word_ptr++;
+
+        // Prepare for processing the next glyph.
+        utf8_word_ptr += curr_glyph_length;
+    }
+
+    // Null-terminate the UTF-32 sequence.
+    *utf32_word_ptr = 0;
+
+    return utf32_word;
+}
 
 /*===========================================================================
 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 ./fbtextdemo font.ttf -x 30 -y 30 -f 50 -w 700 -c To be or not to be...
-./fbtextdemo font.ttf -x 100 -y 70 -f 30    That is the question. 
-
+./fbtextdemo font.ttf -x 100 -y 70 -f 30    That is the question.
+./fbtextdemo font.ttf -x 100 -y 100 -f 30    á é í ó ú ñ.


### PR DESCRIPTION
Add support for multi-byte glyphs, such as `á é í ó ú ñ`.