### PR TITLE
fix: -d/--dev option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+fbtextdemo

--- a/src/main.c
+++ b/src/main.c
@@ -543,7 +543,7 @@ int main (int argc, char **argv)
     
       char *error = NULL;
 
-      FrameBuffer *fb = framebuffer_create (FBDEV);
+      FrameBuffer *fb = framebuffer_create (fbdev);
 
       // Initializing the framebuffer may fail, particularly if the user
       //   doesn't have permissions.


### PR DESCRIPTION
A simple fix in main.c to make the -d/--dev pick up the device to use.